### PR TITLE
Add specs for Badge administration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,6 @@
 inherit_gem:
   decidim-dev: rubocop-decidim.yml
+
+RSpec/DescribeClass:
+  Exclude:
+    - "spec/system/**/*"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     decidim-badges (0.31.1)
-      decidim-admin (= 0.31.1)
-      decidim-core (= 0.31.1)
+      decidim-admin (~> 0.31.1)
+      decidim-core (~> 0.31.1)
       deface
 
 GEM

--- a/app/cells/decidim/badge/show.erb
+++ b/app/cells/decidim/badge/show.erb
@@ -10,5 +10,5 @@
     </div>
   </div>
   <div class="profile__badge-name"><%= decidim_sanitize_translated(badge.name) %></div>
-  <div class="profile__badge-description"><%= translated_attribute(badge.description) %></div>
+  <div class="profile__badge-description"><%= decidim_sanitize_translated(badge.description) %></div>
 </div>

--- a/app/commands/decidim/badges/admin/destroy_badge.rb
+++ b/app/commands/decidim/badges/admin/destroy_badge.rb
@@ -3,33 +3,15 @@
 module Decidim
   module Badges
     module Admin
-      class DestroyBadge < Decidim::Command
-        # Public: Initializes the command.
-        #
-        # badge - The badge to destroy
-        def initialize(badge)
-          @badge = badge
-        end
-
-        # Executes the command. Broadcasts these events:
-        #
-        # - :ok when everything is valid.
-        # - :invalid if the form was not valid and we could not proceed.
-        #
-        # Returns nothing.
-        def call
-          destroy_badge
-          broadcast(:ok)
-        rescue StandardError
-          broadcast(:invalid)
-        end
-
+      class DestroyBadge < Decidim::Commands::DestroyResource
         private
 
-        def destroy_badge
-          Decidim.traceability.perform_action!("delete", @badge, current_user) do
-            @badge.destroy!
-          end
+        def extra_params
+          {
+            resource: {
+              title: resource.name
+            }
+          }
         end
       end
     end

--- a/app/commands/decidim/badges/admin/reorder_badges.rb
+++ b/app/commands/decidim/badges/admin/reorder_badges.rb
@@ -10,7 +10,9 @@ module Decidim
         end
 
         def call
-          reorder_steps
+          return broadcast(:invalid) if order.blank?
+
+          reorder_badges
           broadcast(:ok)
         end
 
@@ -18,7 +20,7 @@ module Decidim
 
         attr_reader :organization, :order
 
-        def reorder_steps
+        def reorder_badges
           transaction do
             reset_weights
             collection.reload
@@ -56,7 +58,7 @@ module Decidim
         # rubocop:enable Rails/SkipsModelValidations
 
         def collection
-          @collection ||= Decidim::Badges::Badge.where(organization: current_organization)
+          @collection ||= Decidim::Badges::Badge.where(organization:)
         end
       end
     end

--- a/app/controllers/decidim/badges/organization/admin/badge_controller.rb
+++ b/app/controllers/decidim/badges/organization/admin/badge_controller.rb
@@ -61,7 +61,7 @@ module Decidim
           def destroy
             enforce_permission_to_update_resource
 
-            Decidim::Badges::Admin::DestroyBadge.call(badge) do
+            Decidim::Badges::Admin::DestroyBadge.call(badge, current_user) do
               on(:ok) do
                 flash.now[:success] = t("decidim.badges.admin.badge.destroy.success")
               end

--- a/app/models/decidim/badges/badge.rb
+++ b/app/models/decidim/badges/badge.rb
@@ -8,6 +8,7 @@ module Decidim
       include Decidim::Traceable
       include Decidim::Loggable
       include Decidim::Publicable
+      # include Decidim::SoftDeletable
 
       belongs_to :organization, class_name: "Decidim::Organization", foreign_key: :decidim_organization_id
       belongs_to :participatory_space, polymorphic: true, optional: true

--- a/app/models/decidim/badges/badge.rb
+++ b/app/models/decidim/badges/badge.rb
@@ -5,6 +5,7 @@ module Decidim
     class Badge < ApplicationRecord
       include Decidim::HasAttachments
       include Decidim::HasUploadValidations
+      include Decidim::Traceable
       include Decidim::Loggable
       include Decidim::Publicable
 

--- a/decidim-badges.gemspec
+++ b/decidim-badges.gemspec
@@ -24,8 +24,7 @@ Gem::Specification.new do |s|
     end
   end
 
-  s.add_dependency "decidim-admin", Decidim::Badges.version
-  s.add_dependency "decidim-core", Decidim::Badges.version
+  s.add_dependency "decidim-admin", "~> 0.31.1"
+  s.add_dependency "decidim-core", "~> 0.31.1"
   s.add_dependency "deface"
-  s.add_development_dependency "decidim-dev", Decidim::Badges.version
 end

--- a/decidim-badges.gemspec
+++ b/decidim-badges.gemspec
@@ -10,8 +10,7 @@ Gem::Specification.new do |s|
   s.email = ["contact@alecslupu.ro"]
   s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
-  s.metadata = {
-  }
+  s.metadata = {}
   s.required_ruby_version = "~> 3.3"
 
   s.name = "decidim-badges"
@@ -25,8 +24,8 @@ Gem::Specification.new do |s|
     end
   end
 
-  s.add_dependency "decidim-core", Decidim::Badges.version
   s.add_dependency "decidim-admin", Decidim::Badges.version
+  s.add_dependency "decidim-core", Decidim::Badges.version
   s.add_dependency "deface"
   s.add_development_dependency "decidim-dev", Decidim::Badges.version
 end

--- a/lib/decidim/badges/engine.rb
+++ b/lib/decidim/badges/engine.rb
@@ -42,9 +42,7 @@ module Decidim
             Decidim::Proposals::Admin::NotifyProposalAnswer.prepend(Decidim::Badges::Overwrites::NotifyProposalAnswer)
           end
 
-          if Decidim.module_installed?(:meetings)
-            Decidim::Meetings::WithdrawMeeting.prepend(Decidim::Badges::Overwrites::WithdrawMeeting)
-          end
+          Decidim::Meetings::WithdrawMeeting.prepend(Decidim::Badges::Overwrites::WithdrawMeeting) if Decidim.module_installed?(:meetings)
 
           Decidim::CreateFollow.prepend Decidim::Badges::Overwrites::CreateFollow
           Decidim::DeleteFollow.prepend Decidim::Badges::Overwrites::DeleteFollow

--- a/lib/decidim/badges/overwrites/badges_controller.rb
+++ b/lib/decidim/badges/overwrites/badges_controller.rb
@@ -5,6 +5,8 @@ module Decidim
     module Overwrites
       module BadgesController
         def index
+          raise ActionController::RoutingError, "Not Found" unless current_organization.badges_enabled?
+
           @badges = Decidim::Badges::Badge.where(organization: current_organization).published
         end
       end

--- a/lib/decidim/badges/test/factories.rb
+++ b/lib/decidim/badges/test/factories.rb
@@ -4,5 +4,20 @@ require "decidim/components/namer"
 require "decidim/core/test/factories"
 
 FactoryBot.define do
-  # Add engine factories here
+  factory :badge, class: "Decidim::Badges::Badge" do
+    transient do
+      skip_injection { false }
+    end
+    organization { create(:organization, skip_injection:) }
+    name { generate_localized_title(:badge_name, skip_injection:) }
+    description { generate_localized_description(:badge_description, skip_injection:) }
+    earning_methods { generate_localized_title(:badge_earning_methods, skip_injection:) }
+    published_at { Time.current }
+    weight { 0 }
+    levels { { "0" => "1", "1" => "5", "2" => "6", "3" => "10", "4" => "40" } }
+    participatory_space { create(:participatory_process, organization: organization, skip_injection:) }
+    component { nil }
+    manifest_name { "comment_created" }
+    file { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
+  end
 end

--- a/lib/decidim/badges/test/factories.rb
+++ b/lib/decidim/badges/test/factories.rb
@@ -7,17 +7,33 @@ FactoryBot.define do
   factory :badge, class: "Decidim::Badges::Badge" do
     transient do
       skip_injection { false }
+      create_component { true }
     end
     organization { create(:organization, skip_injection:) }
     name { generate_localized_title(:badge_name, skip_injection:) }
-    description { generate_localized_description(:badge_description, skip_injection:) }
+    description { generate_localized_description(:badge_description, skip_injection:, before: "", after: "") }
     earning_methods { generate_localized_title(:badge_earning_methods, skip_injection:) }
     published_at { Time.current }
     weight { 0 }
     levels { { "0" => "1", "1" => "5", "2" => "6", "3" => "10", "4" => "40" } }
-    participatory_space { create(:participatory_process, organization: organization, skip_injection:) }
+    participatory_space { create(:participatory_process, organization:, skip_injection:) }
     component { nil }
     manifest_name { "comment_created" }
     file { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
+
+    after(:build) do |badge, evaluator|
+      if badge.participatory_space.present? && evaluator.create_component == true
+        badge.component = create(:dummy_component, participatory_space: badge.participatory_space, skip_injection: evaluator.skip_injection)
+      end
+    end
+    trait :unpublished do
+      published_at { nil }
+    end
+  end
+
+  factory :badge_score, class: "Decidim::Badges::BadgeScore" do
+    badge { create(:badge) }
+    user { create(:user, :confirmed, organization: badge.organization) }
+    value { 5 }
   end
 end

--- a/spec/commands/decidim/badges/admin/create_badge_spec.rb
+++ b/spec/commands/decidim/badges/admin/create_badge_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Badges
+    module Admin
+      describe CreateBadge do
+        subject { described_class.new(form) }
+        let(:organization) { create(:organization) }
+        let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+        let(:form) do
+          BadgeForm.from_params(
+            name: Decidim::Faker::Localized.name,
+            earning_methods: Decidim::Faker::Localized.sentences(number: 2),
+            description: Decidim::Faker::Localized.sentences(number: 2),
+            participatory_space_type: nil,
+            participatory_space_id: nil,
+            decidim_component_id: nil,
+            file: upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg")),
+            manifest_name: "proposal_created",
+            levels: {
+              "0" => 1,
+              "1" => 3,
+              "2" => 5,
+              "3" => 10,
+              "4" => 20
+            }
+          ).with_context(current_organization: organization, current_user: user)
+        end
+
+        context "when form is invalid" do
+          before do
+            allow(form).to receive(:valid?).and_return(false)
+          end
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when the form is valid" do
+          before do
+            form.valid?
+            expect(form.errors).to be_empty
+          end
+
+          it "broadcasts ok" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "creates a new badge" do
+            expect { subject.call }.to change(Badges::Badge, :count).by(1)
+          end
+
+          it "updates the file of the badge" do
+            expect(badge.file).to be_attached
+            expect(badge.file.filename).to eq("city.jpeg")
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability).to receive(:create).with(
+              Decidim::Badges::Badge,
+              user,
+              hash_including(:name, :organization, :earning_methods, :description, :levels,
+                             :participatory_space_type, :participatory_space_id, :decidim_component_id, :manifest_name)
+            ).and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count).by(1)
+            action_log = Decidim::ActionLog.last!
+            expect(action_log.version).to be_present
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/badges/admin/destroy_badge_spec.rb
+++ b/spec/commands/decidim/badges/admin/destroy_badge_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Badges
+    module Admin
+      describe DestroyBadge do
+        subject { described_class.new(badge, user) }
+
+        let(:organization) { create(:organization) }
+        let(:user) { create(:user, :admin, :confirmed, organization:) }
+        let!(:badge) { create(:badge, organization:) }
+
+        it "destroys the member" do
+          subject.call
+          expect { badge.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "broadcasts ok" do
+          expect do
+            subject.call
+          end.to broadcast(:ok)
+        end
+
+        it "traces the action", versioning: true do
+          expect(Decidim.traceability)
+            .to receive(:perform_action!)
+            .with(
+              :delete,
+              badge,
+              user,
+              resource: { title: badge.name }
+            )
+            .and_call_original
+
+          expect { subject.call }.to change(Decidim::ActionLog, :count)
+          action_log = Decidim::ActionLog.last
+          expect(action_log.version).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/badges/admin/reorder_badges_spec.rb
+++ b/spec/commands/decidim/badges/admin/reorder_badges_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Badges
+    module Admin
+      describe ReorderBadges do
+        subject { described_class.new(*args) }
+        let(:args) { [organization, order] }
+        let(:organization) { create(:organization) }
+        let(:user) { create(:user, :admin, :confirmed, organization:) }
+        let!(:badge1) { create(:badge, organization:, weight: 0) }
+        let!(:badge2) { create(:badge, organization:, weight: 1) }
+        let!(:badge3) { create(:badge, organization:, weight: 2, published_at: nil) }
+        let(:order) { [badge1.id, badge2.id] }
+
+        context "when the order is nil" do
+          let(:order) { nil }
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when the order is empty" do
+          let(:order) { [] }
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when the order is valid" do
+          it "is valid" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "reorders the blocks" do
+            subject.call
+            badge1.reload
+            badge2.reload
+            badge3.reload
+
+            expect(badge1.weight).to eq 1
+            expect(badge2.weight).to eq 2
+            expect(badge3.weight).to be_nil
+          end
+        end
+
+        context "when scoped resource is present and order is valid" do
+          let(:order) { [badge3.id, badge2.id, badge1.id] }
+
+          it "is valid" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "only affects to content blocks associated with the resource" do
+            expect { subject.call }.not_to change(Decidim::Badges::Badge, :count)
+
+            badge1.reload
+            badge2.reload
+            badge3.reload
+
+            expect(badge1.weight).to eq 3
+            expect(badge2.weight).to eq 2
+            expect(badge3.weight).to eq 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/badges/admin/update_badge_spec.rb
+++ b/spec/commands/decidim/badges/admin/update_badge_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Badges
+    module Admin
+      describe UpdateBadge do
+        subject { described_class.new(form, badge) }
+
+        let(:organization) { create(:organization) }
+        let(:user) { create(:user, :admin, :confirmed, organization:) }
+        let(:badge) { create(:badge, organization:) }
+        let(:invalid) { false }
+
+        let(:participatory_space) { create(:participatory_process, organization:) }
+
+        let(:form) do
+          BadgeForm.from_params(
+            name: {
+              "en" => "New name"
+            },
+            earning_methods: {
+              "en" => "Earning methods"
+            },
+            description: {
+              "en" => "Description field"
+            },
+            participatory_space_type: participatory_space.class.name,
+            participatory_space_id: participatory_space.id,
+            decidim_component_id: nil,
+            file: upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg")),
+            manifest_name: "proposal_created",
+            levels: {
+              "0" => 3,
+              "1" => 7,
+              "2" => 13,
+              "3" => 23,
+              "4" => 70
+            }
+          ).with_context(current_organization: organization, current_user: user)
+        end
+
+        context "when form is invalid" do
+          before do
+            allow(form).to receive(:valid?).and_return(false)
+          end
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when the form is valid" do
+          before do
+            subject.call
+            badge.reload
+          end
+
+          it "updates the name of the badge" do
+            expect(translated(badge.name)).to eq("New name")
+          end
+
+          it "updates the description of the badge" do
+            expect(translated(badge.description)).to eq("Description field")
+          end
+
+          it "updates the earning_methods of the badge" do
+            expect(translated(badge.earning_methods)).to eq("Earning methods")
+          end
+
+          it "updates the participatory_space of the badge" do
+            expect(badge.participatory_space).to eq(participatory_space)
+          end
+
+          it "updates the file of the badge" do
+            expect(badge.file).to be_attached
+            expect(badge.file.filename).to eq("city.jpeg")
+          end
+
+          it "updates the levels of the badge" do
+            expect(badge.levels).to eq({
+                                         "0" => 3,
+                                         "1" => 7,
+                                         "2" => 13,
+                                         "3" => 23,
+                                         "4" => 70
+                                       })
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:update!)
+              .with(badge, user, hash_including(:name, :description, :levels))
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/profile_badge_page_spec.rb
+++ b/spec/system/profile_badge_page_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Visitors checks the profile page" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed, organization:) }
+
+  before do
+    switch_to_host(organization.host)
+    visit decidim.profile_badges_path(nickname: user.nickname)
+  end
+
+  context "when badge system is enabled" do
+    context "when no badge is present" do
+      it "displays the badge information" do
+        expect(page).to have_content("Badges")
+        expect(page).to have_content("Badges are recognitions to participant actions and progress in the platform.")
+      end
+    end
+
+    context "when badge is unpublished" do
+      let!(:badge) { create(:badge, :unpublished, organization:) }
+
+      it "displays the badge information" do
+        expect(page).to have_content("Badges")
+        expect(page).to have_content("Badges are recognitions to participant actions and progress in the platform.")
+
+        expect(page).to have_no_content(translated(badge.name))
+        expect(page).to have_no_content(decidim_sanitize_translated(badge.name))
+      end
+    end
+
+    context "when badge is published" do
+      let!(:badge) { create(:badge, organization:) }
+
+      before do
+        visit current_path
+      end
+
+      it "displays the badge information" do
+        visit current_path
+        expect(page).to have_content("Badges")
+        expect(page).to have_content("Badges are recognitions to participant actions and progress in the platform.")
+
+        expect(page).to have_content(decidim_sanitize_translated(badge.name))
+      end
+
+      context "when component is not present" do
+        let!(:badge) { create(:badge, create_component: false, organization:) }
+
+        it "hides the component information" do
+          expect(page).to have_no_content("component")
+        end
+      end
+
+      context "when user has earned the badge" do
+        context "when user has not earned the badge" do
+          let!(:score) { create(:badge_score, badge:, user:, value: 0) }
+
+          it "displays the badge information" do
+            visit current_path
+            expect(page).to have_content("Level 0")
+          end
+        end
+
+        context "when user has earned the level 1 badge" do
+          let!(:score) { create(:badge_score, badge:, user:, value: 2) }
+
+          it "displays the badge information" do
+            visit current_path
+            expect(page).to have_content("Level 1")
+          end
+        end
+
+        context "when user has earned the level 2 badge" do
+          let!(:score) { create(:badge_score, badge:, user:, value: 5) }
+
+          it "displays the badge information" do
+            visit current_path
+            expect(page).to have_content("Level 2")
+          end
+        end
+
+        context "when user has earned the level 3 badge" do
+          let!(:score) { create(:badge_score, badge:, user:, value: 7) }
+
+          it "displays the badge information" do
+            visit current_path
+            expect(page).to have_content("Level 3")
+          end
+        end
+
+        context "when user has earned the level 4 badge" do
+          let!(:score) { create(:badge_score, badge:, user:, value: 10) }
+
+          it "displays the badge information" do
+            visit current_path
+            expect(page).to have_content("Level 4")
+          end
+        end
+
+        context "when user has earned the level 5 badge" do
+          let!(:score) { create(:badge_score, badge:, user:, value: 41) }
+
+          it "displays the badge information" do
+            visit current_path
+            expect(page).to have_content("Level 5")
+          end
+        end
+
+        context "when user is hyperactive" do
+          let!(:score) { create(:badge_score, badge:, user:, value: 41_000) }
+
+          it "displays the badge information" do
+            visit current_path
+            expect(page).to have_content("Level 5")
+          end
+        end
+      end
+    end
+
+    context "when multiple badges are present" do
+      let!(:badges) { create_list(:badge, 5, organization:) }
+
+      before do
+        visit current_path
+      end
+
+      it "displays the badge information" do
+        expect(page).to have_content("Badges")
+        expect(page).to have_content("Badges are recognitions to participant actions and progress in the platform.")
+        within "#content" do
+          expect(page).to have_css(".profile__badge", count: 5)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/public_badge_page_spec.rb
+++ b/spec/system/public_badge_page_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Visitors checks the badge page" do
+  let(:organization) { create(:organization) }
+
+  before do
+    switch_to_host(organization.host)
+    visit decidim.gamification_badges_path
+  end
+
+  context "when badge system is disabled" do
+    let(:organization) { create(:organization, badges_enabled: false) }
+
+    it "the page is not present" do
+      expect(page).to have_content("Routing Error")
+    end
+  end
+
+  context "when badge system is enabled" do
+    context "when no badge is present" do
+      it "displays the badge information" do
+        expect(page).to have_content("Badges")
+        expect(page).to have_content("Badges are recognitions to participant actions and progress in the platform.")
+      end
+    end
+
+    context "when badge is unpublished" do
+      let!(:badge) { create(:badge, :unpublished, organization:) }
+
+      it "displays the badge information" do
+        expect(page).to have_content("Badges")
+        expect(page).to have_content("Badges are recognitions to participant actions and progress in the platform.")
+
+        expect(page).to have_no_content(translated(badge.name))
+        expect(page).to have_no_content(decidim_sanitize_translated(badge.name))
+      end
+    end
+
+    context "when badge is published" do
+      let!(:badge) { create(:badge, organization:) }
+
+      before do
+        visit current_path
+      end
+
+      it "displays the badge information" do
+        visit current_path
+        expect(page).to have_content("Badges")
+        expect(page).to have_content("Badges are recognitions to participant actions and progress in the platform.")
+
+        expect(page).to have_content(decidim_sanitize_translated(badge.name))
+        expect(page).to have_content(translated(badge.description))
+        expect(page).to have_content(translated(badge.earning_methods))
+      end
+
+      context "when participatory space is present" do
+        it "displays the space information" do
+          expect(page).to have_content("Perform the action in #{translated(badge.participatory_space.title)} space")
+        end
+      end
+
+      context "when participatory space is not present" do
+        let!(:badge) { create(:badge, organization:, participatory_space: nil) }
+
+        it "displays the space information" do
+          expect(page).to have_no_content("Perform the action")
+        end
+      end
+
+      context "when component is present" do
+        it "displays the component information" do
+          expect(page).to have_content("Perform the action in #{translated(badge.component.name)} component")
+        end
+      end
+
+      context "when component is not present" do
+        let!(:badge) { create(:badge, create_component: false, organization:) }
+
+        it "hides the component information" do
+          expect(page).to have_no_content("component")
+        end
+      end
+    end
+
+    context "when multiple badges are present" do
+      let!(:badges) { create_list(:badge, 5, organization:) }
+
+      before do
+        visit current_path
+      end
+
+      it "displays the badge information" do
+        expect(page).to have_content("Badges")
+        expect(page).to have_content("Badges are recognitions to participant actions and progress in the platform.")
+        within "#content" do
+          expect(page).to have_css("h2", count: 5)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the badges system, focusing on better test coverage, improved traceability, and codebase consistency. The most significant changes include the addition of comprehensive RSpec tests for badge-related commands, refactoring of the badge destruction logic to enhance traceability and reuse, and various minor improvements and fixes across the codebase.
